### PR TITLE
Nebblu patch 1

### DIFF
--- a/pyreact/react_wrapper.cpp
+++ b/pyreact/react_wrapper.cpp
@@ -604,10 +604,6 @@ int compute_reaction_nu_ext(int* N_pk_m, double* torpk_m,
       react_error("Values of As and pivot scale are not compatible -  set 1e-3<pscale<0.1  and 1.5e-9<As<2.5e-9");
     }
 
-    if (!*is_transfer) {
-      react_error("You must supply the input transfer functions if using a modified linear input");
-    }
-
     // Special function class
     IOW iow;
     // initialise power spectrum normalisation before running

--- a/reactions/src/SPT.cpp
+++ b/reactions/src/SPT.cpp
@@ -946,8 +946,10 @@ void SPT::ploop_init(double ploopr[], double ploopp[], double redshifts[], int n
 		kargs[0] =1e-4;
 	    }
 	  temp_ps[zi][i] = pow2(k2val[k2i])*2.*P_L(kv[1])*(P_L(kargs[0])*p22[zi] + 3.*P_L(k0)*p13[zi]);
-          temp_psp[zi][i] = pow2(k2val[k2i])*2.*P_L(kv[1])*(P_L(kargs[0])*p22p[zi] + 3.*P_L(k0)*p13p[zi]);
-	 }
+         // temp_psp[zi][i] = pow2(k2val[k2i])*2.*P_L(kv[1])*(P_L(kargs[0])*p22p[zi] + 3.*P_L(k0)*p13p[zi]); // pure GR loop 
+	 temp_psp[zi][i] = pow2(k2val[k2i])*2.*pow2(mykernelarray[zi][14]/mykernelarray[zi][18])*P_L(kv[1])*(pow2(mykernelarray[zi][12]/mykernelarray[zi][16])*P_L(kargs[0])*p22p[zi] + 3.*pow2(mykernelarray[zi][0]/mykernelarray[zi][6])*P_L(k0)*p13p[zi]); // P_L is MG but 22 and 13 kernels are modified 
+
+	  }
 
   // save angular integral per redshift
         for(int zii = 0; zii<noz; zii++){


### PR DESCRIPTION
- Removed redundant error message in the python wrapper's (react_wrapper.cpp) compute_reaction_nu_ext related to supplying a transfer function (the function can take both transfer and power spectra for the species). 

-Corrected an inconsistency in SPT.cpp's ploop_init function. The pseudo 1-loop spectrum was being calculated as P_MG + P^22_GR + P^13_GR which is not the correct pseudo. The correction now multiplies the 1-loop pieces with the appropriate modified growth factors to have the modified linear spectra within the loop integrals. The higher order kernels are still GR.  This is consistent with how all other functions compute the 1-loop pseudo. 


I have tested the latter correction locally and now compute_reaction_nu_ext and compute_reaction_ext give the same output prediction for the reaction when no massive neutrinos are present. 